### PR TITLE
add support for tox, travis-ci and improve test_views.py

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,4 +6,6 @@ omit =
   *tests/*,
   *urls.py,
   *wsgi.py,
+  *__init__.py,
+  */.tox/*,
   manage.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
-*.pyc
-.coverage
 .cache/
+.coverage
+.idea
+.tox/
+
+db.sqlite3
+
+*.pyc
+
 htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+install:
+  - pip install tox
+script:
+  - tox
+env:
+  - TOXENV=django19
+  - TOXENV=django110
+  - TOXENV=coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
 install:
-  - pip install tox
+  - pip install coveralls tox tox-travis
 script:
   - tox
 env:
   - TOXENV=django19
   - TOXENV=django110
   - TOXENV=coverage
+after_success:
+  - coveralls

--- a/birdie/tests/test_views.py
+++ b/birdie/tests/test_views.py
@@ -2,7 +2,6 @@ import pytest
 from django.core import mail
 from django.contrib.auth.models import AnonymousUser
 from django.http import Http404
-from django.test import RequestFactory
 from mock import patch
 from mixer.backend.django import mixer
 pytestmark = pytest.mark.django_db
@@ -11,49 +10,49 @@ from .. import views
 
 
 class TestHomeView:
-    def test_anonymous(self):
-        req = RequestFactory().get('/')
+    def test_anonymous(self, rf):
+        req = rf.get('/')
         resp = views.HomeView.as_view()(req)
         assert resp.status_code == 200, 'Should be callable by anyone'
 
 
 class TestAdminView:
-    def test_anonymous(self):
-        req = RequestFactory().get('/')
+    def test_anonymous(self, rf):
+        req = rf.get('/')
         req.user = AnonymousUser()
         resp = views.AdminView.as_view()(req)
         assert 'login' in resp.url, 'Should redirect to login'
 
-    def test_superuser(self):
+    def test_superuser(self, rf):
         user = mixer.blend('auth.User', is_superuser=True)
-        req = RequestFactory().get('/')
+        req = rf.get('/')
         req.user = user
         resp = views.AdminView.as_view()(req)
         assert resp.status_code == 200, 'Should be callable by superuser'
 
 
 class TestPostUpdateView:
-    def test_get(self):
+    def test_get(self, rf):
         post = mixer.blend('birdie.Post')
-        req = RequestFactory().get('/')
+        req = rf.get('/')
         req.user = AnonymousUser()
         resp = views.PostUpdateView.as_view()(req, pk=post.pk)
         assert resp.status_code == 200, 'Should be callable by anyone'
 
-    def test_post(self):
+    def test_post(self, rf):
         post = mixer.blend('birdie.Post')
         data = {'body': 'New Body Text!'}
-        req = RequestFactory().post('/', data=data)
+        req = rf.post('/', data=data)
         req.user = AnonymousUser()
         resp = views.PostUpdateView.as_view()(req, pk=post.pk)
         assert resp.status_code == 302, 'Should redirect to success view'
         post.refresh_from_db()
         assert post.body == 'New Body Text!', 'Should update the post'
 
-    def test_security(self):
+    def test_security(self, rf):
         user = mixer.blend('auth.User', first_name='Martin')
         post = mixer.blend('birdie.Post')
-        req = RequestFactory().post('/', data={})
+        req = rf.post('/', data={})
         req.user = user
         with pytest.raises(Http404):
             views.PostUpdateView.as_view()(req, pk=post.pk)
@@ -61,9 +60,9 @@ class TestPostUpdateView:
 
 class TestPaymentView:
     @patch('birdie.views.stripe')
-    def test_payment(self, mock_stripe):
+    def test_payment(self, mock_stripe, rf):
         mock_stripe.Charge.return_value = {'id': '234'}
-        req = RequestFactory().post('/', data={'token': '123'})
+        req = rf.post('/', data={'token': '123'})
         resp = views.PaymentView.as_view()(req)
         assert resp.status_code == 302, 'Should redirect to success_url'
         assert len(mail.outbox) == 1, 'Should send an email'

--- a/install/linux.pip
+++ b/install/linux.pip
@@ -3,4 +3,6 @@ mock==2.0.0
 pytest==3.2.3
 pytest-cov==2.5.1
 pytest-django==3.1.2
+pytest-flake8==0.8.1
+pytest-pylint==0.7.1
 stripe==1.66.0

--- a/install/linux.pip
+++ b/install/linux.pip
@@ -1,0 +1,6 @@
+mixer==5.6.6
+mock==2.0.0
+pytest==3.2.3
+pytest-cov==2.5.1
+pytest-django==3.1.2
+stripe==1.66.0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-DJANGO_SETTINGS_MODULE = tested.test_settings
-addopts = --nomigrations

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = django19, django110
 skipsdist = True
 
 [testenv]
+basepython = python2.7
 commands = pytest -v
 
 [base]
@@ -42,11 +43,13 @@ commands = pytest -v --cov=. --cov-report=html
 deps = {[testenv:django19]deps}
 
 [testenv:django19]
+commands = pytest -v --junitxml=django19-result.xml
 deps =
     django>=1.9, <1.10
     {[base]deps}
 
 [testenv:django110]
+commands = pytest -v --junitxml=django110-result.xml
 deps =
     django>=1.10, <1.11
     {[base]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -12,11 +12,12 @@ deps = -r{toxinidir}/install/linux.pip
 max-line-length = 110
 max-complexity = 10
 exclude =
-	.git,
-	.tox,
-	__pycache__,
-	manage.py,
-	*.pyc
+    .cache,
+    .git,
+    .tox,
+    __pycache__,
+    manage.py,
+    *.pyc
 # C901 '*' is too complex
 # E201 whitespace after
 # E202 whitespace before
@@ -25,12 +26,19 @@ exclude =
 ignore = C901,E201,E202,E402,E501
 
 [pytest]
-DJANGO_SETTINGS_MODULE=tested.test_settings
+DJANGO_SETTINGS_MODULE = tested.test_settings
 addopts = --nomigrations --strict
+flake8-exclude = {[flake8]exclude}
+flake8-ignore = {[flake8]ignore}
+flake8-max-line-length = {[flake8]max-line-length}
+flake8-max-complexity = {[flake8]max-complexity}
 norecursedirs = {toxinidir}/.tox
+markers =
+    flake8
+    pylint
 
 [testenv:coverage]
-commands = pytest -v --nomigrations --cov=. --cov-report=html
+commands = pytest -v --cov=. --cov-report=html
 deps = {[testenv:django19]deps}
 
 [testenv:django19]
@@ -44,11 +52,11 @@ deps =
     {[base]deps}
 
 [testenv:flake8]
-commands = flake8
-deps = flake8
+commands = pytest -v --junitxml=flake8-result.xml --flake8
+deps =
+    {[testenv:django19]deps}
 
 [testenv:pylint]
-commands = pylint --rcfile=~/.pylintrc tested birdie
+commands = pytest -v --junitxml=pylint-result.xml --pylint --pylint-rcfile=~/.pylintrc
 deps =
-    pylint
     {[testenv:django19]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,54 @@
+[tox]
+envlist = django19, django110
+skipsdist = True
+
+[testenv]
+commands = pytest -v
+
+[base]
+deps = -r{toxinidir}/install/linux.pip
+
+[flake8]
+max-line-length = 110
+max-complexity = 10
+exclude =
+	.git,
+	.tox,
+	__pycache__,
+	manage.py,
+	*.pyc
+# C901 '*' is too complex
+# E201 whitespace after
+# E202 whitespace before
+# E402 module level import not at top of file
+# E501 line too long
+ignore = C901,E201,E202,E402,E501
+
+[pytest]
+DJANGO_SETTINGS_MODULE=tested.test_settings
+addopts = --nomigrations --strict
+norecursedirs = {toxinidir}/.tox
+
+[testenv:coverage]
+commands = pytest -v --nomigrations --cov=. --cov-report=html
+deps = {[testenv:django19]deps}
+
+[testenv:django19]
+deps =
+    django>=1.9, <1.10
+    {[base]deps}
+
+[testenv:django110]
+deps =
+    django>=1.10, <1.11
+    {[base]deps}
+
+[testenv:flake8]
+commands = flake8
+deps = flake8
+
+[testenv:pylint]
+commands = pylint --rcfile=~/.pylintrc tested birdie
+deps =
+    pylint
+    {[testenv:django19]deps}


### PR DESCRIPTION
- add tox.ini and remove pytest.ini: now both tox and pytest can be used
- add support to run the tests on travis-ci.org
- use fixture for RequestFactory()